### PR TITLE
Updated background image in light mode fix #74

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background-image:url("https://user-images.githubusercontent.com/72564975/112663760-32405600-8e7f-11eb-8131-d8c8accf605c.jpg");
+  background-image:url("https://user-images.githubusercontent.com/72564975/112664111-9b27ce00-8e7f-11eb-957f-3add5deca3dc.jpg");
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
@@ -9,7 +9,7 @@ body {
 }
 
 body.dark-bg {
-  background-image: url("https://user-images.githubusercontent.com/72564975/112664271-cad6d600-8e7f-11eb-93c1-7c59b3329c49.jpg");
+  background-image: url("https://i.pinimg.com/originals/85/ec/df/85ecdf1c3611ecc9b7fa85282d9526e0.jpg");
 }
 
 code {


### PR DESCRIPTION
Changed background image in light mode as it was a bit loud and distracting
Before
![Messenger - Google Chrome 03-04-2021 15_40_42 (2)](https://user-images.githubusercontent.com/72564975/113475432-55789000-9493-11eb-9b02-6abd2cbc74ea.png)
After
![Messenger - Google Chrome 03-04-2021 11_34_49 (2)](https://user-images.githubusercontent.com/72564975/113475441-60332500-9493-11eb-94f8-9cd4a1fee102.png)

